### PR TITLE
删除两处console.log

### DIFF
--- a/lib/internal/contactable.ts
+++ b/lib/internal/contactable.ts
@@ -141,7 +141,6 @@ export abstract class Contactable{
 			n += 20
 		}
 		this.c.logger.debug(`图片任务结束`)
-		console.log(res1)
 		return res1
 	}
 

--- a/lib/internal/highway.ts
+++ b/lib/internal/highway.ts
@@ -120,7 +120,6 @@ export function highwayUpload(this: Client, readable: stream.Readable, obj: High
                     obj.callback(percentage)
                 if (Number(percentage) >= 100) {
                     socket.end()
-                    console.log(rsp[7])
                     resolve(rsp[7])
                 }
             }


### PR DESCRIPTION
删除两处触发消息及图片回复时的console.log，防止日志杂乱