### PR TITLE
fix: 修复特殊文件(文件名带%)的链接无法正常下载

### DIFF
--- a/lib/gfs.ts
+++ b/lib/gfs.ts
@@ -419,7 +419,7 @@ export class Gfs {
 		checkRsp(rsp)
 		return {
 			name: file.name,
-			url: `http://${rsp[4]}/ftn_handler/${rsp[6].toHex()}/?fname=${file.name}`,
+			url: encodeURI(`http://${rsp[4]}/ftn_handler/${rsp[6].toHex()}/?fname=${file.name}`),
 			size: file.size,
 			md5: file.md5,
 			duration: file.duration,


### PR DESCRIPTION
<!--
- 新API和事件的添加务必事先达成共识(包括命名、参数、分类等)
- 若需引入新依赖，务必事先达成共识
- 务必检查自己的代码是否与周围画风不同
- 代码规范基本遵循以下规则：
  * 缩进使用tab，行末不写分号(必须要写请写在下一行的开头)
  * 类型用大驼峰，function型用小驼峰，常量用大写+下划线，其他用小写+下划线，文件名全小写
-->
https://github.com/takayama-lily/oicq/pull/481