### PR TITLE
change device json read method

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -172,7 +172,9 @@ export class Client extends BaseClient {
         const file = path.join(dir, `device.json`)
         let device: ShortDevice, isNew: boolean = false
         try {
-            device = require(file) as ShortDevice
+            // device = require(file) as ShortDevice
+            const rawFile = fs.readFileSync(file)
+            device = JSON.parse(rawFile.toString()) as ShortDevice
         } catch {
             device = generateShortDevice()
             isNew = true


### PR DESCRIPTION
device.json的读取方式从require切换到fs， 用以修复前端使用require()无法解析绝对路径的问题