### PR TITLE
Backport aPad protocol to 8.8.88

### DIFF
--- a/src/core/device.ts
+++ b/src/core/device.ts
@@ -329,8 +329,8 @@ const apklist: { [platform in Platform]: Apk } = {
     [Platform.Android]: mobile,
     [Platform.old_Android]: old_mobile,
     [Platform.aPad]: {
-        ...mobile,
-        subid: 537155599,
+        ...old_mobile,
+        subid: 537118044,
         display: 'aPad'
     },
     [Platform.Watch]: watch,


### PR DESCRIPTION
This pull request proposes to backport the aPad protocol version to 8.8.88 in order to fix the login issue that some users have encontered. The current version of the protocol (8.9.58) seems to have some signing problems with Tencent's server and causes authentication errors. By rolling back to the previous stable version without sign validation, it's verified to log in again with this protocol.
Idea from mamoe/mirai.