### PR TITLE
Support ESModule

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,3 +20,4 @@ export { PrivateMessageEvent, GroupMessageEvent, DiscussMessageEvent, MessageRet
 export { ApiRejection, Device, Apk, Platform, Domain } from "./core"
 export * as core from "./core"
 export { OcrResult } from "./internal"
+Object.defineProperty(exports, "default", { enumerable: true, get: () => exports });


### PR DESCRIPTION
单单仅为了支持对 esm 的基本支持
即常规 import icqq from 'icqq' 中使用 icqq 对象不报错。