### PR TITLE
chore: 不将 Mirai 类型的 MessageElem 中的文本添加到 Message 的 brief 和 content

### DIFF
--- a/src/message/parser.ts
+++ b/src/message/parser.ts
@@ -243,10 +243,9 @@ export class Parser {
                 break
             case 31: //mirai
                 if (proto[3] === 103904510) {
-                    brief = content = String(proto[2])
                     elem = {
                         type: "mirai",
-                        data: brief,
+                        data: String(proto[2]),
                     }
                 } else {
                     return


### PR DESCRIPTION
<!--
- 新API和事件的添加务必事先达成共识(包括命名、参数、分类等)
- 若需引入新依赖，务必事先达成共识
- 务必检查自己的代码是否与周围画风不同
- 代码规范基本遵循以下规则：
  * 缩进使用tab，行末不写分号(必须要写请写在下一行的开头)
  * 类型用大驼峰，function型用小驼峰，常量用大写+下划线，其他用小写+下划线，文件名全小写
-->

因为普通的客户端不会显示这些内容，做消息匹配之类的时候，mirai 中的附加内容也不应该参与匹配