### PR TITLE
fix: 合并转发使用预处理

### DIFF
--- a/src/internal/contactable.ts
+++ b/src/internal/contactable.ts
@@ -613,11 +613,7 @@ export abstract class Contactable {
                 }
             }
 
-            const maker = new Converter(fake.message, {
-                dm: this.dm,
-                cachedir: path.join(this.c.dir, "image"),
-            })
-
+            const maker = await this._preprocess(fake.message)
             if (maker?.brief && brief) {
                 maker.brief = brief
             }
@@ -692,10 +688,6 @@ export abstract class Contactable {
             }
         })
 
-        for (const maker of makers)
-            imgs = [...imgs, ...maker.imgs]
-        if (imgs.length)
-            await this.uploadImages(imgs)
         const compressed = await gzip(pb.encode({
             //1: nodes,
             2: MultiMsg


### PR DESCRIPTION
<!--
- 新API和事件的添加务必事先达成共识(包括命名、参数、分类等)
- 若需引入新依赖，务必事先达成共识
- 务必检查自己的代码是否与周围画风不同
- 代码规范基本遵循以下规则：
  * 缩进使用tab，行末不写分号(必须要写请写在下一行的开头)
  * 类型用大驼峰，function型用小驼峰，常量用大写+下划线，其他用小写+下划线，文件名全小写
-->
让合并转发支持发送更多消息类型